### PR TITLE
Fix for missing E-518 commands

### DIFF
--- a/pigcs2App/src/PIE517Controller.cpp
+++ b/pigcs2App/src/PIE517Controller.cpp
@@ -71,4 +71,17 @@ asynStatus PIE517Controller::getNrOutputChannels()
 
 }
 
-
+asynStatus PIE517Controller::getStatus(PIasynAxis* pAxis, int& homing, int& moving, int& negLimit, int& posLimit, int& servoControl)
+{
+	asynStatus status = getMoving(pAxis, moving);
+	if (status != asynSuccess)
+	{
+		return status;
+	}
+	
+	homing = 0;
+	negLimit = 0;
+	posLimit = 0;
+	
+	return status;
+}

--- a/pigcs2App/src/PIE517Controller.h
+++ b/pigcs2App/src/PIE517Controller.h
@@ -32,6 +32,8 @@ public:
 	PIE517Controller(PIInterface* pInterface, const char* szIDN)
 	: PIGCSPiezoController(pInterface, szIDN)
 	{
+		m_hasqFRF = false;
+		m_hasqTRS = false;
 	}
 	~PIE517Controller() {}
 
@@ -41,6 +43,7 @@ public:
 		// E-517 does support HLT with single axis
 		return PIGCSController::haltAxis(pAxis);
 	}
+	virtual asynStatus getStatus(PIasynAxis* pAxis, int& homing, int& moving, int& negLimit, int& posLimit, int& servoControl);
 
 private:
     asynStatus setOnline(int outputChannel, int onlineState);

--- a/pigcs2App/src/PIGCSPiezoController.h
+++ b/pigcs2App/src/PIGCSPiezoController.h
@@ -44,7 +44,7 @@ public:
     virtual asynStatus referenceVelCts( PIasynAxis* pAxis, double velocity, int forwards);
 
 
-private:
+protected:
     bool m_hasqFRF; ///< is "FRF?" command available
     bool m_hasqTRS; ///< is "TRS?" command available
 


### PR DESCRIPTION
Changes from Steffen Rau to eliminate errors due to missing FRF, TRS and SRG commands for the PI E-518 controller.