### PR TITLE
Fixed VxWorks build problem

### DIFF
--- a/pigcs2App/src/PIE727Controller.cpp
+++ b/pigcs2App/src/PIE727Controller.cpp
@@ -23,6 +23,10 @@ Created: 15.12.2010
 PIE727Controller::PIE727Controller(PIInterface* pInterface, const char* szIDN)
 : PIGCSPiezoController (pInterface, szIDN)
 {
+    this->m_CCL_ADVANCED_ID = 1;   // advanced user ID
+    this->m_CCL_DEFAULT_ID  = 0;   // default user ID
+    strcpy(this->m_CCL_ADVANCED_PWD, "advanced");   // advanced user password
+    
     this->m_hasqFRF=false; ///< is "FRF?" command available
     this->m_hasqTRS=false; ///< is "TRS?" command available
     this->m_hasqSRG=false;

--- a/pigcs2App/src/PIE727Controller.h
+++ b/pigcs2App/src/PIE727Controller.h
@@ -47,7 +47,7 @@ class PIE727Controller : public PIGCSPiezoController
 		unsigned int m_CCL_ADVANCED_ID;   // advanced user ID
 		unsigned int m_CCL_DEFAULT_ID;   // default user ID
 
-		char m_CCL_ADVANCED_PWD[8];   // advanced user password
+		char m_CCL_ADVANCED_PWD[9];   // advanced user password
 };
 
 #endif /* PIE727CONTROLLER_H_ */

--- a/pigcs2App/src/PIE727Controller.h
+++ b/pigcs2App/src/PIE727Controller.h
@@ -44,11 +44,10 @@ class PIE727Controller : public PIGCSPiezoController
 
 		asynStatus setGCSCmdLvl(unsigned int cmdLvl);
 		
-		const unsigned int m_CCL_ADVANCED_ID = 1;   // advanced user ID
-		const unsigned int m_CCL_DEFAULT_ID  = 0;   // default user ID
+		unsigned int m_CCL_ADVANCED_ID;   // advanced user ID
+		unsigned int m_CCL_DEFAULT_ID;   // default user ID
 
-
-		const char *m_CCL_ADVANCED_PWD  = "advanced";   // default user ID
+		char m_CCL_ADVANCED_PWD[8];   // advanced user password
 };
 
 #endif /* PIE727CONTROLLER_H_ */


### PR DESCRIPTION
Initialize the default user ID, advanced user ID, and advanced user password in the constructor instead of the header file for compatibility with pre-C++11 compilers.

Fixes #17 