### PR TITLE
Set m_hasqSRG=false if SRG response is empty

### DIFF
--- a/pigcs2App/src/PIGCSPiezoController.cpp
+++ b/pigcs2App/src/PIGCSPiezoController.cpp
@@ -41,6 +41,7 @@ asynStatus PIGCSPiezoController::getStatus(PIasynAxis* pAxis, int& homing, int& 
         const char* p = strstr(buf, "=");
         if (p==NULL || *p == '\0')
         {
+            m_hasqSRG = false;
             return asynError;
         }
 


### PR DESCRIPTION
The E-709 responds to the SRG query with an empty string, which currently results in errors every time the controller is polled.

Set m_hasqSRG if asynError is returned because the response to the SRG query was empty.