### PR TITLE
Coordinate System (CS) Support for C-887 Controller

### DIFF
--- a/iocs/pigcs2IOC/iocBoot/iocPIGCS2/PI_GCS2_hexapod.cmd
+++ b/iocs/pigcs2IOC/iocBoot/iocPIGCS2/PI_GCS2_hexapod.cmd
@@ -1,0 +1,19 @@
+# PI GCS2 support
+
+dbLoadTemplate("PI_GCS2_hexapod.substitutions")
+
+drvAsynIPPortConfigure("C887_ETH","10.32.4.52:4001")
+
+# Turn on asyn trace
+asynSetTraceMask("C887_ETH",0,3)
+asynSetTraceIOMask("C887_ETH",0,1)
+
+# PI_GCS2_CreateController(portName, asynPort, numAxes, priority, stackSize, movingPollingRate, idlePollingRate)
+PI_GCS2_CreateController("C887", "C887_ETH",6, 0, 0, 100, 1000)
+
+# Turn off asyn trace
+asynSetTraceMask("C887_ETH",0,1)
+asynSetTraceIOMask("C887_ETH",0,0)
+
+# asyn record for troubleshooting
+#dbLoadRecords("$(ASYN)/db/asynRecord.db","P=$(P),R=asyn_1,PORT=C887_ETH,ADDR=0,OMAX=256,IMAX=256")

--- a/iocs/pigcs2IOC/iocBoot/iocPIGCS2/PI_GCS2_hexapod.substitutions
+++ b/iocs/pigcs2IOC/iocBoot/iocPIGCS2/PI_GCS2_hexapod.substitutions
@@ -1,0 +1,46 @@
+file "$(MOTOR)/motorApp/Db/basic_asyn_motor_model2.db"
+{
+pattern
+#Hexapod model H-850
+{P,        M,            DTYP,    PORT, ADDR,      DESC,  EGU,  DIR,  VELO,  VBAS,  ACCL,  BDST,  BVEL,  BACC,  MRES,  PREC,  DHLM,  DLLM,  HLM, LLM, INIT}
+{pigcs2:,  "X",  "asynMotor",  "C887",    0,  "X", mm,      Pos,     0.5,     0,    0,    0,      0.5,    0,  1e-4,  4,     0,   0.0, 50.0, -50.0, ""}
+{pigcs2:,  "Y",  "asynMotor",  "C887",    1,  "Y", mm,      Pos,     0.5,     0,    0,    0,      0.5,    0,  1e-4,  4,     0,   0.0, 25.0, -25.0, ""}
+{pigcs2:,  "Z",  "asynMotor",  "C887",    2,  "Z", mm,      Pos,     0.5,     0,    0,    0,      0.5,    0,  1e-4,  4,     0,   0.0, 50.0, -50.0, ""}
+{pigcs2:,  "U",  "asynMotor",  "C887",    3,  "U", degree,  Pos,     0.5,     0,    0,    0,      0.5,    0,  1e-4,  4,     0,   0.0, 15.0, -15.0, ""}
+{pigcs2:,  "V",  "asynMotor",  "C887",    4,  "V", degree,  Pos,     0.5,     0,    0,    0,      0.5,    0,  1e-4,  4,     0,   0.0, 30.0, -30.0, ""}
+{pigcs2:,  "W",  "asynMotor",  "C887",    5,  "W", degree,  Pos,     0.5,     0,    0,    0,      0.5,    0,  1e-4,  4,     0,   0.0, 15.0, -15.0, ""}
+}
+
+file "$(TOP)/db/PI_Support.db"
+{
+pattern
+{P,          M,     PORT,    ADDR,    TIMEOUT }
+{pigcs2:,  "X:",  "C887",     0,        1   }
+{pigcs2:,  "Y:",  "C887",     1,        1   }
+{pigcs2:,  "Z:",  "C887",     2,        1   }
+{pigcs2:,  "U:",  "C887",     3,        1   }
+{pigcs2:,  "V:",  "C887",     4,        1   }
+{pigcs2:,  "W:",  "C887",     5,        1   }
+}
+
+#file "$(TOP)/db/PI_SupportCtrl.db"
+#{
+#pattern
+#{P,           PORT  }
+#{pigcs2:,  "C887" }
+#}
+
+file "$(TOP)/db/PI_SupportError.db"
+{
+pattern
+{P,           PORT  }
+{pigcs2:,  "C887" }
+}
+
+#Coordinate System
+file "$(TOP)/db/PI_SupportCS.db"
+{
+pattern
+{P,           PORT  }
+{pigcs2:,  "C887" }
+}

--- a/iocs/pigcs2IOC/iocBoot/iocPIGCS2/st.cmd
+++ b/iocs/pigcs2IOC/iocBoot/iocPIGCS2/st.cmd
@@ -15,6 +15,7 @@ dbLoadRecords("$(MOTOR)/db/motorUtil.db", "P=pigcs2:")
 
 ##
 < PI_GCS2.cmd
+#< PI_GCS2_hexapod.cmd
 
 iocInit
 

--- a/iocs/pigcs2IOC/pigcs2App/Db/Makefile
+++ b/iocs/pigcs2IOC/pigcs2App/Db/Makefile
@@ -13,12 +13,14 @@ DB_INSTALLS += $(MOTOR_PIGCS2)/db/PI_SupportError.db
 DB_INSTALLS += $(MOTOR_PIGCS2)/db/PI_SupportCtrl.db
 DB_INSTALLS += $(MOTOR_PIGCS2)/db/PI_SupportCL.db
 DB_INSTALLS += $(MOTOR_PIGCS2)/db/PI_Support.db
+DB_INSTALLS += $(MOTOR_PIGCS2)/db/PI_SupportCS.db
 else
 ### this module was built inside motor/modules
 DB_INSTALLS += $(MOTOR)/db/PI_SupportError.db
 DB_INSTALLS += $(MOTOR)/db/PI_SupportCtrl.db
 DB_INSTALLS += $(MOTOR)/db/PI_SupportCL.db
 DB_INSTALLS += $(MOTOR)/db/PI_Support.db
+DB_INSTALLS += $(MOTOR)/db/PI_SupportCS.db
 endif
 
 #----------------------------------------------------

--- a/pigcs2App/Db/Makefile
+++ b/pigcs2App/Db/Makefile
@@ -16,6 +16,7 @@ DB += PI_SupportCtrl.db
 DB += PI_SupportError.db
 DB += PI_Support.db
 DB += PI_SupportCL.db
+DB += PI_SupportCS.db
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add

--- a/pigcs2App/Db/PI_Support.db
+++ b/pigcs2App/Db/PI_Support.db
@@ -32,3 +32,18 @@ record(bi, "$(P)$(M)RBSERVO")
    field(SCAN, "I/O Intr")
 }
 
+record(ai, "$(P)$(M)HLM")
+{
+	field(DTYP, "asynFloat64")
+	field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))MOTOR_HIGH_LIMIT")
+	field(PREC, "5")
+	field(SCAN, "I/O Intr")
+}
+
+record(ai, "$(P)$(M)LLM")
+{
+	field(DTYP, "asynFloat64")
+	field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))MOTOR_LOW_LIMIT")
+	field(PREC, "5")
+	field(SCAN, "I/O Intr")
+}

--- a/pigcs2App/Db/PI_SupportCS.db
+++ b/pigcs2App/Db/PI_SupportCS.db
@@ -1,0 +1,92 @@
+# Support based on Work and Tool Coordinate system
+
+#The work-and-tool concept can be used for work with user-defined
+#coordinate systems.
+#The work-and-tool concept uses a combination of two active -->
+#operating coordinate systems ("work coordinate system" and "tool
+#coordinate system"). The X, Y, and Z axes of the tool coordinate system
+#are permanently connected to the motion platform of the hexapod;
+#i.e., the tool coordinate system moves together with the platform. The
+#X, Y, and Z axes of the work coordinate system are always spatially
+#fixed (in relation to the hexapod); i.e., the work coordinate system
+#does not move when the platform of the hexapod moves.
+#The current position of the motion platform of the hexapod can be
+#considered the position of the tool coordinate system in the work
+#coordinate system.
+#The center of rotation always lies at the origin of the tool coordinate
+#system and it therefore moves just as the tool coordinate system with
+#the platform.
+
+#Set Target Absolute Move, Relative In Tool or Relative In Work Coordinate System in motor record controller. 
+record(mbbo, "$(P)CS_TARGETMODE") {
+    field(DESC, "Set target mode")
+    field(DTYP, "asynInt32")
+    field(ZRST, "Absolute Position")           field(ZRVL, 0)
+    field(ONST, "Relative In Tool CS")         field(ONVL, 1)
+    field(TWST, "Relative In Work CS")         field(TWVL, 2)
+    field(VAL, "0")
+    field(OUT,  "@asyn($(PORT),0,0)PI_CS_TARGETMODE")
+}
+
+#Get Target Absolute move, Relative In Tool or Relative In Work Coordinate System in motor record controller.
+record(mbbi, "$(P)CS_RBTARGETMODE") {
+    field(DESC, "Get target mode")
+    field(DTYP, "asynInt32")
+    field(ZRST, "Absolute Position")           field(ZRVL, 0)
+    field(ONST, "Relative In Tool CS")         field(ONVL, 1)
+    field(TWST, "Relative In Work CS")         field(TWVL, 2)
+    field(INP,  "@asyn($(PORT),0,0)PI_CS_TARGETMODE")
+    field(SCAN, "I/O Intr")
+}
+
+#Activates the specified coordinate system.
+record(stringout, "$(P)CS_ACTIVATE") {
+   field(DESC, "Activate Coordinate System")
+   field(DTYP, "asynOctetWrite")
+   field(OUT, "@asyn($(PORT),0,0)PI_CS_ACTIVATE")
+}
+
+#Lists the names of all the active coordinate systems and displays their type.
+record(waveform, "$(P)CS_RBACTIVES")
+{  
+   field(DESC, "Get All the Active Coordinate Systems") 
+	field(DTYP, "asynOctetRead")
+   field(FTVL, "CHAR")
+	field(INP, "@asyn($(PORT),0,0)PI_CS_ACTIVATE")
+	field(SCAN, "I/O Intr")
+   field(NELM, "1000")
+}
+
+#Links two coordinate systems (Tool and Work) to create a chain of ChildCS and ParentCS (Example: "ChildCS ParentCS")
+record(stringout, "$(P)CS_LINK") {
+   field(DESC, "Set Link CS Child and Parent")
+   field(DTYP, "asynOctetWrite")
+   field(OUT, "@asyn($(PORT),0,0)PI_CS_LINK")
+}
+
+#Lists the components of the existing coordinate system.
+record(waveform, "$(P)CS_RBLINK")
+{  
+   field(DESC, "Get Coordinate System Chains") 
+	field(DTYP, "asynOctetRead")
+   field(FTVL, "CHAR")
+	field(INP, "@asyn($(PORT),0,0)PI_CS_LINK")
+	field(SCAN, "I/O Intr")
+   field(NELM, "1000")
+}
+
+#Define Tool Coordinate System Offset to specific CSname and Axis. (Command example: "CSName X 2.0").
+#If CSName does not exist, a new CSName Tool will be created.
+record(stringout, "$(P)CS_KST_OFFSET") {
+   field(DESC, "Set Tool CS Offset")
+   field(DTYP, "asynOctetWrite")
+   field(OUT, "@asyn($(PORT),0,0)PI_CS_KST")
+}
+
+#Define Work Coordinate System Offset to specific CSname and Axis. (Example: "CSname X 2.0").
+#If CSName does not exist, a new CSName Work will be created.
+record(stringout, "$(P)CS_KSW_OFFSET") {
+   field(DESC, "Set Work CS Offset")
+   field(DTYP, "asynOctetWrite")
+   field(OUT, "@asyn($(PORT),0,0)PI_CS_KSW")
+}

--- a/pigcs2App/src/Makefile
+++ b/pigcs2App/src/Makefile
@@ -30,6 +30,7 @@ PI_GCS2Support_SRCS += PIC885Controller.cpp
 PI_GCS2Support_SRCS += PIGCSMotorControllerNoRefVel.cpp
 PI_GCS2Support_SRCS += TranslatePIError.cpp
 PI_GCS2Support_SRCS += PIInterface.cpp
+PI_GCS2Support_SRCS += PICoordinateSystem.cpp
 
 PI_GCS2Support_LIBS += motor
 PI_GCS2Support_LIBS += asyn

--- a/pigcs2App/src/PICoordinateSystem.cpp
+++ b/pigcs2App/src/PICoordinateSystem.cpp
@@ -1,0 +1,174 @@
+/*
+FILENAME...     PICoordinateSystem.cpp
+
+Author: Guilherme Rodrigues de Lima
+Email: guilherme.lima@lnls.br
+Created: 05.03.2024
+*/
+
+#include "PICoordinateSystem.h"
+#include "PIasynAxis.h"
+#include "PIInterface.h"
+
+asynStatus PICoordinateSystem::getStatus(PIasynAxis* pAxis, int& homing, int& moving, int& negLimit, int& posLimit, int& servoControl)
+{
+    char cmd[100];
+    char buf[255];
+    asynStatus status = asynSuccess;
+
+    status = getMoving(pAxis, moving);
+    if (status != asynSuccess)
+    {
+        return status;
+    }
+
+    homing = 0;
+    negLimit = 0; 
+    posLimit = 0;
+    
+    status = getServo(pAxis, servoControl);
+    if (status != asynSuccess)
+    {
+        return status;
+    } 
+
+    return status;
+}
+
+asynStatus PICoordinateSystem::setActivate(const char* value)
+{
+    char cmd[100];
+    char buf[255];
+
+    sprintf(cmd, "KEN %s", value);
+    asynStatus status = m_pInterface->sendOnly(cmd);
+    
+    if (status != asynSuccess)
+    {
+        return status;
+    }
+
+    return status;
+}
+
+asynStatus PICoordinateSystem::getActivate(std::string &value)
+{
+    char cmd[100];
+    char buf[255];
+
+    sprintf(cmd, "KEN?");
+
+    asynStatus status = m_pInterface->sendAndReceive(cmd, buf, 255);
+    value = std::string(buf);
+    value.erase(remove(value.begin(), value.end(), '\n'), value.end());
+
+    if (status != asynSuccess)
+    {
+        return status;
+    }
+    
+    return status;
+}
+
+asynStatus PICoordinateSystem::getLink(std::string &value)
+{
+    char cmd[100];
+    char buf[255];
+
+    sprintf(cmd, "KLN?");
+
+    asynStatus status = m_pInterface->sendAndReceive(cmd, buf, 255);
+    value = std::string(buf);
+    value.erase(remove(value.begin(), value.end(), '\n'), value.end());
+    replace(value.begin(), value.end(), '\t', ' ');
+
+    if (status != asynSuccess)
+    {
+        return status;
+    }
+    
+    return status;
+}
+
+asynStatus PICoordinateSystem::setLink(const char* value)
+{
+    char cmd[100];
+    char buf[255];
+
+    sprintf(cmd, "KLN %s", value);
+    asynStatus status = m_pInterface->sendOnly(cmd);
+    
+    if (status != asynSuccess)
+    {
+        return status;
+    }
+
+    return status;
+}
+
+asynStatus PICoordinateSystem::setToolOffset(const char* value)
+{
+    char cmd[100];
+    char buf[255];
+
+    sprintf(cmd, "KST %s", value);
+    asynStatus status = m_pInterface->sendOnly(cmd);
+    
+    if (status != asynSuccess)
+    {
+        return status;
+    }
+
+    return status;
+}
+
+asynStatus PICoordinateSystem::setWorkOffset(const char* value)
+{
+    char cmd[100];
+    char buf[255];
+
+    sprintf(cmd, "KSW %s", value);
+    asynStatus status = m_pInterface->sendOnly(cmd);
+    
+    if (status != asynSuccess)
+    {
+        return status;
+    }
+
+    return status;
+}
+
+asynStatus PICoordinateSystem::getTravelLimits(PIasynAxis* pAxis, double& negLimit, double& posLimit)
+{   
+    char cmd[100];
+    char buf[255];
+    asynStatus status = asynSuccess;
+
+    sprintf(cmd, "TRA? %s -1", pAxis->m_szAxisName);
+    status = m_pInterface->sendAndReceive(cmd, buf, 255);
+
+    if (status != asynSuccess)
+    {
+        return status;
+    }
+
+    if (!getValue(buf, negLimit))
+    {
+        return asynError;
+    }
+
+    sprintf(cmd, "TRA? %s 1", pAxis->m_szAxisName);
+    status = m_pInterface->sendAndReceive(cmd, buf, 255);
+
+    if (status != asynSuccess)
+    {
+        return status;
+    }
+
+    if (!getValue(buf, posLimit))
+    {
+        return asynError;
+    }
+
+    return status;
+}

--- a/pigcs2App/src/PICoordinateSystem.h
+++ b/pigcs2App/src/PICoordinateSystem.h
@@ -1,0 +1,44 @@
+/*
+FILENAME...     PICoordinateSystem.cpp
+
+Original Author: Guilherme Rodrigues de Lima
+Created: 05.03.2024
+*/
+
+#ifndef PICOORDINATESYSTEM_H_
+#define PICOORDINATESYSTEM_H_
+
+#include <string>
+#include <iostream>
+#include <algorithm>
+#include "PIGCS2_HexapodController.h"
+using namespace std;
+
+class PICoordinateSystem : public PIGCS2_HexapodController
+{
+public:
+	PICoordinateSystem(PIInterface* pInterface, const char* szIDN)
+	: PIGCS2_HexapodController(pInterface, szIDN)
+	{
+	}
+	~PICoordinateSystem() {}
+
+	virtual asynStatus getStatus(PIasynAxis* pAxis, int& homing, int& moving, int& negLimit, int& posLimit, int& servoControl);
+	
+	virtual asynStatus setActivate(const char* value);
+	virtual asynStatus getActivate(string &value);
+
+	virtual asynStatus setLink(const char* value);
+	virtual asynStatus getLink(string &value);
+
+	virtual asynStatus setToolOffset(const char* value);
+	virtual asynStatus setWorkOffset(const char* value);
+
+	virtual asynStatus getTravelLimits(PIasynAxis* pAxis, double& negLimit, double& posLimit);
+
+protected:
+
+private:
+};
+
+#endif /* PICOORDINATESYSTEM_H_ */

--- a/pigcs2App/src/PIGCSController.cpp
+++ b/pigcs2App/src/PIGCSController.cpp
@@ -29,6 +29,7 @@ Created: 15.12.2010
 #include "PIC885Controller.h"
 #include "PIGCSMotorControllerNoRefVel.h"
 #include "TranslatePIError.h"
+#include "PICoordinateSystem.h"
 
 
 //#undef asynPrint
@@ -91,7 +92,6 @@ PIGCSController* PIGCSController::CreateGCSController(PIInterface* pInterface, c
 				||	strstr(szIDN, "F-HEX") != NULL
 				||	strstr(szIDN, "F-206") != NULL
 				||	strstr(szIDN, "M-8") != NULL
-				||	strstr(szIDN, "C-887") != NULL
 		)
 	{
 		if (IsGCSVersion(pInterface, 2.0))
@@ -102,6 +102,10 @@ PIGCSController* PIGCSController::CreateGCSController(PIInterface* pInterface, c
 		{
 			return new PIHexapodController(pInterface, szIDN);
 		}
+	}
+	else if (strstr(szIDN, "C-887") != NULL) 
+	{
+		return new PICoordinateSystem(pInterface, szIDN);
 	}
 	else
 	{

--- a/pigcs2App/src/PIGCSController.h
+++ b/pigcs2App/src/PIGCSController.h
@@ -17,8 +17,8 @@ Created: 15.12.2010
 
 #include <asynDriver.h>
 #include <string.h>
+#include <string>
 #include "picontrollererrors.h"
-
 
 class PIasynAxis;
 class asynMotorAxis;
@@ -85,6 +85,14 @@ public:
     virtual double GetPivotY() { return 0.0; }
     virtual double GetPivotZ() { return 0.0; }
 
+    // Coordinate System
+    virtual asynStatus setActivate(const char* value){return asynSuccess;}
+    virtual asynStatus getActivate(std::string &value){return asynSuccess;}
+    virtual asynStatus setLink(const char* value){return asynSuccess;}
+    virtual asynStatus getLink(std::string &value){return asynSuccess;}
+    virtual asynStatus setToolOffset(const char* value){return asynSuccess;}
+    virtual asynStatus setWorkOffset(const char* value){return asynSuccess;}
+
     // Closed loop parameters
     virtual asynStatus setCLAxisParam( PIasynAxis* pAxis, unsigned int paramID,  double value ){return asynSuccess;} 
     virtual asynStatus getCLAxisParam( PIasynAxis* pAxis, unsigned int paramID, double& value ){value=0.0; return asynSuccess;}
@@ -109,6 +117,7 @@ public:
     static const size_t MAX_NR_AXES = 64;
 	bool m_bAnyAxisMoving;
     int m_LastError;
+    int m_targetMode = 0;
 
     static void getStatusFromBitMask(long mask, int& homing, int& moving, int& negLimit, int& posLimit, int& servoControl);
 

--- a/pigcs2App/src/PIHexapodController.cpp
+++ b/pigcs2App/src/PIHexapodController.cpp
@@ -22,48 +22,48 @@ Original Author: Steffen Rau
 
 asynStatus PIHexapodController::init(void)
 {
-	asynStatus status = PIGCSController::init();
-	if (status != asynSuccess)
-	{
-		return status;
-	}
+    asynStatus status = PIGCSController::init();
+    if (status != asynSuccess)
+    {
+        return status;
+    }
 
-	// Try to find out if #4 is supported
-	char buf[200];
-	status = m_pInterface->sendAndReceive(char(4), buf, 199);
-	if (status == asynSuccess)
-	{
-		m_bCanReadStatusWithChar4 = true;
-	}
-	else if (status == asynTimeout)
-	{
-		m_bCanReadStatusWithChar4 = false;
-		getGCSError(); // clear error UNKNOWN COMMAND
-	}
-	status = m_pInterface->sendAndReceive(char(3), buf, 199);
-	if (status == asynSuccess)
-	{
-		m_bCanReadPosWithChar3 = true;
-	}
-	else if (status == asynTimeout)
-	{
-		m_bCanReadPosWithChar3 = false;
-		getGCSError(); // clear error UNKNOWN COMMAND
-	}
+    // Try to find out if #4 is supported
+    char buf[255];
+    status = m_pInterface->sendAndReceive(char(4), buf, 255);
+    if (status == asynSuccess)
+    {
+        m_bCanReadStatusWithChar4 = true;
+    }
+    else if (status == asynTimeout)
+    {
+        m_bCanReadStatusWithChar4 = false;
+        getGCSError(); // clear error UNKNOWN COMMAND
+    }
+    status = m_pInterface->sendAndReceive(char(3), buf, 255);
+    if (status == asynSuccess)
+    {
+        m_bCanReadPosWithChar3 = true;
+    }
+    else if (status == asynTimeout)
+    {
+        m_bCanReadPosWithChar3 = false;
+        getGCSError(); // clear error UNKNOWN COMMAND
+    }
 
-	m_bHoming = false;
+    m_bHoming = false;
 
-	ReadPivotSettings();
+    ReadPivotSettings();
 
-	return status;
+    return status;
 }
 
 
 asynStatus PIHexapodController::getGlobalState(asynMotorAxis** pAxes, int numAxes)
 {
-	// do not call moving here, at least simulation software does return
-	// values != 0 with bit 1 not set (e.g. "2")
-	char buf[255];
+    // do not call moving here, at least simulation software does return
+    // values != 0 with bit 1 not set (e.g. "2")
+    char buf[255];
     asynStatus status = m_pInterface->sendAndReceive(char(5), buf, 99);;
     if (status != asynSuccess)
     {
@@ -76,11 +76,11 @@ return status;
     m_bAnyAxisMoving = (moving != 0);
     if (m_bHoming && (moving == 0))
     {
-    	m_bHoming = false;
+        m_bHoming = false;
     }
     for(int i=0; i<numAxes; i++)
     {
-    	((PIasynAxis*)pAxes[i])->m_bMoving = (moving != 0);
+        ((PIasynAxis*)pAxes[i])->m_bMoving = (moving != 0);
     }
     return asynSuccess;
 
@@ -89,59 +89,59 @@ return status;
 asynStatus PIHexapodController::getStatus(PIasynAxis* pAxis, int& homing, int& moving, int& negLimit, int& posLimit, int& servoControl)
 {
     negLimit = 0;
-   	posLimit = 0;
-   	homing = m_bHoming ? 1:0;
+       posLimit = 0;
+       homing = m_bHoming ? 1:0;
 
-   	moving = pAxis->m_bMoving || pAxis->deferred_move;
+       moving = pAxis->m_bMoving || pAxis->deferred_move;
     return asynSuccess;
 }
 
 asynStatus PIHexapodController::findConnectedAxes()
 {
-	for (size_t i=0; i<MAX_NR_AXES; i++)
-	{
-		m_axesIDs[i] = NULL;
-	}
-	sprintf(m_allAxesIDs, "X\nY\nZ\nU\nV\nW");
-	char* szAxis = strtok(m_allAxesIDs, "\n");
-	while (szAxis != NULL)
-	{
-		int i=strlen(szAxis)-1;
-		while (szAxis[i] == ' ')
-		{
-			szAxis[i] = '\0';
-			i--;
-		}
-		if (MAX_NR_AXES <= m_nrFoundAxes)
-		{
-			return asynError;
-		}
-		m_axesIDs[m_nrFoundAxes] = szAxis;
-		m_nrFoundAxes++;
-		szAxis = strtok(NULL, "\n");
-	}
-	return asynSuccess;
+    for (size_t i=0; i<MAX_NR_AXES; i++)
+    {
+        m_axesIDs[i] = NULL;
+    }
+    sprintf(m_allAxesIDs, "X\nY\nZ\nU\nV\nW");
+    char* szAxis = strtok(m_allAxesIDs, "\n");
+    while (szAxis != NULL)
+    {
+        int i=strlen(szAxis)-1;
+        while (szAxis[i] == ' ')
+        {
+            szAxis[i] = '\0';
+            i--;
+        }
+        if (MAX_NR_AXES <= m_nrFoundAxes)
+        {
+            return asynError;
+        }
+        m_axesIDs[m_nrFoundAxes] = szAxis;
+        m_nrFoundAxes++;
+        szAxis = strtok(NULL, "\n");
+    }
+    return asynSuccess;
 }
 
 asynStatus PIHexapodController::initAxis(PIasynAxis* pAxis)
 {
     pAxis->m_movingStateMask = 1;
-	return setServo(pAxis, 1);
+    return setServo(pAxis, 1);
 }
 
 asynStatus PIHexapodController::getReferencedState(PIasynAxis* pAxis)
 {
-	if (!m_bCanReadStatusWithChar4)
-	{
-	    pAxis->m_homed = 1;
-	    return asynSuccess;
-	}
+    if (!m_bCanReadStatusWithChar4)
+    {
+        pAxis->m_homed = 1;
+        return asynSuccess;
+    }
 
-	char buf[255];
+    char buf[255];
     asynStatus status = m_pInterface->sendAndReceive(char(4), buf, 99);
     if (status != asynSuccess)
     {
-    	return status;
+        return status;
     }
     long mask = strtol(buf, NULL, 10);
     pAxis->m_homed = (mask & 0x10000) ? 1 : 0;
@@ -151,14 +151,22 @@ asynStatus PIHexapodController::getReferencedState(PIasynAxis* pAxis)
 asynStatus PIHexapodController::moveCts( PIasynAxis* pAxis, int targetCts )
 {
 //	printf("PIHexapodController::moveCts(,%d)...\n",targetCts);
-	asynStatus status;
-	char cmd[100];
-	double target = double(targetCts) * pAxis->m_CPUdenominator / pAxis->m_CPUnumerator;
-    sprintf(cmd,"MOV %s %f", pAxis->m_szAxisName, target);
+    asynStatus status;
+    char cmd[100];
+    if(m_targetMode == 0) {
+        double target = double(targetCts) * pAxis->m_CPUdenominator / pAxis->m_CPUnumerator;
+        sprintf(cmd,"MOV %s %f", pAxis->m_szAxisName, target);
+    } else if (m_targetMode == 1) {
+        double relative = double(targetCts - pAxis->m_positionCts) * pAxis->m_CPUdenominator / pAxis->m_CPUnumerator;
+        sprintf(cmd,"MRT %s %f", pAxis->m_szAxisName, relative);
+    } else if (m_targetMode == 2) {
+        double relative = double(targetCts - pAxis->m_positionCts) * pAxis->m_CPUdenominator / pAxis->m_CPUnumerator;
+        sprintf(cmd,"MRW %s %f", pAxis->m_szAxisName, relative);
+    }
     status = m_pInterface->sendOnly(cmd);
     if (asynSuccess != status)
     {
-    	return status;
+        return status;
     }
     epicsThreadSleep( 0.2 ); // TODO test if we do need this
     asynMotorAxis* pAsynAxis = (asynMotorAxis*)pAxis;
@@ -166,7 +174,7 @@ asynStatus PIHexapodController::moveCts( PIasynAxis* pAxis, int targetCts )
     if (asynSuccess != status)
     {
 //    	printf("PIHexapodController::moveCts(,%d) - getGlobalState() failed, status=%d\n", targetCts, status);
-    	return status;
+        return status;
     }
     if (!pAxis->m_bMoving)
     {
@@ -174,49 +182,49 @@ asynStatus PIHexapodController::moveCts( PIasynAxis* pAxis, int targetCts )
 //    	printf("PIHexapodController::moveCts(,%d) - not moving after MOV() gcserror=%d\n",targetCts, errorCode);
         if (errorCode != 0)
         {
-		asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_ERROR,
-        		"PIHexapodController::moveCts() failed, GCS error %d\n", errorCode);
-        	return asynError;
+        asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_ERROR,
+                "PIHexapodController::moveCts() failed, GCS error %d\n", errorCode);
+            return asynError;
         }
     }
     m_bAnyAxisMoving = true;
     pAxis->m_lastDirection = (targetCts > pAxis->m_positionCts) ? 1 : 0;
-	printf("PIHexapodController::moveCts(,%d) - OK!\n",targetCts);
-   	return status;
+    //printf("PIHexapodController::moveCts(,%d) - OK!\n",targetCts);
+       return status;
 }
 
 asynStatus PIHexapodController::moveCts( PIasynAxis** pAxesArray, int* pTargetCtsArray, int numAxes)
 {
-	asynStatus status;
-	char cmd[1000] = "MOV";
-	char subCmd[100];
-	for (int axis = 0; axis <numAxes; axis++)
-	{
-		PIasynAxis* pAxis = pAxesArray[axis];
-		double target = double(pTargetCtsArray[axis]) * pAxis->m_CPUdenominator / pAxis->m_CPUnumerator;
-		sprintf(subCmd," %s %f", pAxis->m_szAxisName, target);
-		strcat(cmd, subCmd);
-	    pAxis->m_lastDirection = (pTargetCtsArray[axis] > pAxis->m_positionCts) ? 1 : 0;
-	}
+    asynStatus status;
+    char cmd[1000] = "MOV";
+    char subCmd[100];
+    for (int axis = 0; axis <numAxes; axis++)
+    {
+        PIasynAxis* pAxis = pAxesArray[axis];
+        double target = double(pTargetCtsArray[axis]) * pAxis->m_CPUdenominator / pAxis->m_CPUnumerator;
+        sprintf(subCmd," %s %f", pAxis->m_szAxisName, target);
+        strcat(cmd, subCmd);
+        pAxis->m_lastDirection = (pTargetCtsArray[axis] > pAxis->m_positionCts) ? 1 : 0;
+    }
     status = m_pInterface->sendOnly(cmd);
     if (asynSuccess != status)
     {
-    	return status;
+        return status;
     }
     epicsThreadSleep(0.2);
     status = getGlobalState((asynMotorAxis**)pAxesArray, numAxes);
     if (asynSuccess != status)
     {
-    	return status;
+        return status;
     }
     if (!pAxesArray[0]->m_bMoving)
     {
         int errorCode = getGCSError();
         if (errorCode != 0)
         {
-		asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_ERROR,
-        		"PIHexapodController::moveCts() failed, GCS error %d\n", errorCode);
-        	return asynError;
+        asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_ERROR,
+                "PIHexapodController::moveCts() failed, GCS error %d\n", errorCode);
+            return asynError;
         }
     }
     m_bAnyAxisMoving = true;
@@ -226,209 +234,210 @@ asynStatus PIHexapodController::moveCts( PIasynAxis** pAxesArray, int* pTargetCt
 
 asynStatus PIHexapodController::getAxisPosition(PIasynAxis* pAxis, double& position)
 {
-	//m_pInterface->m_pCurrentLogSink = m_pInterface;
-	if (!m_bAnyAxisMoving)
-	{
-		return PIGCSController::getAxisPosition(pAxis, position);
-	}
-	if (m_bCanReadPosWithChar3)
-	{
-		char buf[255];
-		asynStatus status = m_pInterface->sendAndReceive(char(3), buf, 99);
-		if (status != asynSuccess)
-		{
-			return status;
-		}
-		char *pStart = buf;
-		for(;;)
-		{
-			bool bEnd = false;
-			while(*pStart == ' ') pStart++;
-			char *pLF = strstr(pStart, "\n");
-			if (pLF != NULL)
-			{
-				*pLF = '\0';
-			}
-			else
-			{
-				bEnd = true;
-			}
-			// single line will look like "X = 1.0 \n"
-			if (pStart[0] == pAxis->m_szAxisName[0] )
-			{
-				double value;
-				if (!getValue(pStart, value))
-				{
-					return asynError;
-				}
-				position = value;
-				return status;
-			}
-			if (bEnd)
-			{
-				break;
-			}
-			pStart = pLF + 1;
-			if (*pStart == '\0')
-			{
-				break;
-			}
-		}
-		// should not come here!
-		return asynError;
-	}
-	// return last position
+    //m_pInterface->m_pCurrentLogSink = m_pInterface;
+    if (!m_bAnyAxisMoving)
+    {
+        return PIGCSController::getAxisPosition(pAxis, position);
+    }
+    if (m_bCanReadPosWithChar3)
+    {
+        char buf[255];
+        asynStatus status = m_pInterface->sendAndReceive(char(3), buf, 255);
+        if (status != asynSuccess)
+        {
+            return status;
+        }
+        char *pStart = buf;
+        for(;;)
+        {
+            bool bEnd = false;
+            while(*pStart == ' ') pStart++;
+            char *pLF = strstr(pStart, "\n");
+            if (pLF != NULL)
+            {
+                *pLF = '\0';
+            }
+            else
+            {
+                bEnd = true;
+            }
+            // single line will look like "X = 1.0 \n"
+            if (pStart[0] == pAxis->m_szAxisName[0] )
+            {
+                double value;
+                if (!getValue(pStart, value))
+                {
+                    return asynError;
+                }
+                position = value;
+                return status;
+            }
+            if (bEnd)
+            {
+                break;
+            }
+            pStart = pLF + 1;
+            if (*pStart == '\0')
+            {
+                break;
+            }
+        }
+        // should not come here!
+        return asynError;
+    }
+    // return last position
     position = double(pAxis->m_positionCts) * double(pAxis->m_CPUdenominator) / double(pAxis->m_CPUnumerator);
-
-	return asynSuccess;
+    return asynSuccess;
 }
 
 asynStatus PIHexapodController::SetPivotX(double value)
 {
     if (NULL != m_pInterface->m_pCurrentLogSink)
     {
-    	asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_FLOW,
-    			"PIHexapodController::SetPivotX() value %f", value);
+        asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_FLOW,
+                "PIHexapodController::SetPivotX() value %f", value);
     }
     asynStatus status = SetPivot('R', value);
-	if (status== asynSuccess)
-	{
-		m_PivotX = value;
-	}
-	return status;
+    if (status== asynSuccess)
+    {
+        m_PivotX = value;
+    }
+    return status;
 }
 
 asynStatus PIHexapodController::SetPivotY(double value)
 {
     if (NULL != m_pInterface->m_pCurrentLogSink)
     {
-    	asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_FLOW,
-   		 "PIHexapodController::SetPivotY() value %f", value);
+        asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_FLOW,
+            "PIHexapodController::SetPivotY() value %f", value);
     }
     asynStatus status = SetPivot('S', value);
-	if (status== asynSuccess)
-	{
-		m_PivotY = value;
-	}
-	return status;
+    if (status== asynSuccess)
+    {
+        m_PivotY = value;
+    }
+    return status;
 }
 
 asynStatus PIHexapodController::SetPivotZ(double value)
 {
     if (NULL != m_pInterface->m_pCurrentLogSink)
     {
-    	asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_FLOW,
-   		 "PIHexapodController::SetPivotZ() value %f", value);
+        asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_FLOW,
+            "PIHexapodController::SetPivotZ() value %f", value);
     }
-	asynStatus status = SetPivot('T', value);
-	if (status== asynSuccess)
-	{
-		m_PivotZ = value;
-	}
-	return status;
+    asynStatus status = SetPivot('T', value);
+    if (status== asynSuccess)
+    {
+        m_PivotZ = value;
+    }
+    return status;
 }
 
 asynStatus PIHexapodController::SetPivot(char cAxis, double value)
 {
-	if (m_bAnyAxisMoving)
-	{
-	    if (NULL != m_pInterface->m_pCurrentLogSink)
-	    {
-	    	asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_FLOW,
-    			"PIHexapodController::SetPivot() cannot change pivot point while platform is moving");
-	    }
-	    return asynError;
-	}
+    if (m_bAnyAxisMoving)
+    {
+        if (NULL != m_pInterface->m_pCurrentLogSink)
+        {
+            asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_FLOW,
+                "PIHexapodController::SetPivot() cannot change pivot point while platform is moving");
+        }
+        return asynError;
+    }
 
-	asynStatus status;
-	char cmd[100];
+    asynStatus status;
+    char cmd[100];
     sprintf(cmd,"SPI %c %f", cAxis, value);
     status = m_pInterface->sendOnly(cmd);
     if (asynSuccess != status)
     {
-    	return status;
+        return status;
     }
 
     int errorCode = getGCSError();
     if (errorCode != 0)
     {
-	asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_ERROR,
-    		"PIHexapodController::SetPivot() failed, GCS error %d\n", errorCode);
-    	return asynError;
+    asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_ERROR,
+            "PIHexapodController::SetPivot() failed, GCS error %d\n", errorCode);
+        return asynError;
     }
-	return status;
+    return status;
 
 }
 
 asynStatus PIHexapodController::ReadPivotSettings()
 {
-	char buf[100];
-	const char* cmd = GetReadPivotCommand();
-	asynStatus status = m_pInterface->sendAndReceive(cmd, buf, 99);
-	if (status != asynSuccess)
-	{
-		return status;
-	}
-	char* pStart = buf;
-	bool bEnd = false;
-	double px = 0.0;
-	double py = 0.0;
-	double pz = 0.0;
-	for(;;)
-	{
-		while(*pStart == ' ') pStart++;
-		char *pLF = strstr(pStart, "\n");
-		if (pLF != NULL)
-		{
-			*pLF = '\0';
-		}
-		else
-		{
-			bEnd = true;
-		}
-		// single line will look like "R = 1.0 \n"
-		double value;
-		if (!getValue(pStart, value))
-		{
-			return asynError;
-		}
-		switch(pStart[0])
-		{
-			case'R': px = value; break;
-			case'S': py = value; break;
-			case'T': pz = value; break;
-		}
-		if (bEnd)
-		{
-			break;
-		}
-		pStart = pLF + 1;
-		if (*pStart == '\0')
-		{
-			break;
-		}
-	}
-	m_PivotX = px;
-	m_PivotY = py;
-	m_PivotZ = pz;
-
-	return status;
+    char buf[100];
+    const char* cmd = GetReadPivotCommand();
+    asynStatus status = m_pInterface->sendAndReceive(cmd, buf, 99);
+    if (status != asynSuccess)
+    {
+        return status;
+    }
+    int errorCode = getGCSError();
+    if (errorCode == 0) {
+        char* pStart = buf;
+        bool bEnd = false;
+        double px = 0.0;
+        double py = 0.0;
+        double pz = 0.0;
+        for(;;)
+        {
+            while(*pStart == ' ') pStart++;
+            char *pLF = strstr(pStart, "\n");
+            if (pLF != NULL)
+            {
+                *pLF = '\0';
+            }
+            else
+            {
+                bEnd = true;
+            }
+            // single line will look like "R = 1.0 \n"
+            double value;
+            if (!getValue(pStart, value))
+            {
+                return asynError;
+            }
+            switch(pStart[0])
+            {
+                case'R': px = value; break;
+                case'S': py = value; break;
+                case'T': pz = value; break;
+            }
+            if (bEnd)
+            {
+                break;
+            }
+            pStart = pLF + 1;
+            if (*pStart == '\0')
+            {
+                break;
+            }
+        }
+        m_PivotX = px;
+        m_PivotY = py;
+        m_PivotZ = pz;
+    }
+    return status;
 }
 
 asynStatus PIHexapodController::referenceVelCts( PIasynAxis* pAxis, double velocity, int forwards)
 {
-	asynStatus status = m_pInterface->sendOnly("INI X");
-	if (asynSuccess != status)
-	{
-		int errorCode = getGCSError();
-	   asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_ERROR,
-	    		"PIHexapodController::referenceVelCts() failed\n");
-		epicsSnprintf(pAxis->m_pasynUser->errorMessage,pAxis->m_pasynUser->errorMessageSize,
-			"PIHexapodController::referenceVelCts() failed - GCS Error %d\n",errorCode);
-		return status;
-	}
-	m_bHoming = true;
- 	return asynSuccess;
+    asynStatus status = m_pInterface->sendOnly("INI X");
+    if (asynSuccess != status)
+    {
+        int errorCode = getGCSError();
+       asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_ERROR,
+                "PIHexapodController::referenceVelCts() failed\n");
+        epicsSnprintf(pAxis->m_pasynUser->errorMessage,pAxis->m_pasynUser->errorMessageSize,
+            "PIHexapodController::referenceVelCts() failed - GCS Error %d\n",errorCode);
+        return status;
+    }
+    m_bHoming = true;
+     return asynSuccess;
 }
 
 asynStatus PIHexapodController::haltAxis(PIasynAxis* pAxis)
@@ -436,15 +445,15 @@ asynStatus PIHexapodController::haltAxis(PIasynAxis* pAxis)
     asynStatus status = m_pInterface->sendOnly(char(24));
     if (status != asynSuccess)
     {
-    	return status;
+        return status;
     }
     //epicsThreadSleep(0.1); // TODO test value
     int err = getGCSError();
-	// controller will set error code to PI_CNTR_STOP (10)
+    // controller will set error code to PI_CNTR_STOP (10)
     if (err != PI_CNTR_STOP)
     {
         asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_ERROR,
-        		"PIGCSController::haltAxis() failed, GCS error %d", err);
+                "PIGCSController::haltAxis() failed, GCS error %d", err);
         return asynError;
     }
     return status;

--- a/pigcs2App/src/PIInterface.cpp
+++ b/pigcs2App/src/PIInterface.cpp
@@ -49,13 +49,13 @@ asynStatus PIInterface::sendOnly(const char *outputBuff, asynUser* logSink)
     asynStatus status;
 
     asynPrint(logSink, ASYN_TRACEIO_DRIVER,
-    		"PIInterface::sendOnly() sending \"%s\"\n", outputBuff);
+            "PIInterface::sendOnly() sending \"%s\"\n", outputBuff);
     //printf("PIInterface::sendOnly() sending \"%s\"\n", outputBuff);
 
     status = pasynOctetSyncIO->write(m_pAsynInterface, outputBuff,
                                      nRequested, TIMEOUT, &nActual);
     if (nActual != nRequested)
-		status = asynError;
+        status = asynError;
     status = pasynOctetSyncIO->write(m_pAsynInterface, "\n",
                                      1, TIMEOUT, &nActual);
     if (status != asynSuccess)
@@ -73,13 +73,13 @@ asynStatus PIInterface::sendOnly(char c, asynUser* logSink)
     asynStatus status;
 
     asynPrint(logSink, ASYN_TRACEIO_DRIVER,
-    		"PIInterface::sendOnly() sending \"#%d\"\n", int(c));
+            "PIInterface::sendOnly() sending \"#%d\"\n", int(c));
     //printf("PIInterface::sendOnly() sending \"#%d\"\n", int(c));
 
     status = pasynOctetSyncIO->write(m_pAsynInterface, &c,
                                      1, TIMEOUT, &nActual);
     if (nActual != 1)
-		status = asynError;
+        status = asynError;
     if (status != asynSuccess)
     {
         asynPrint(logSink, ASYN_TRACE_ERROR|ASYN_TRACEIO_DRIVER,
@@ -99,30 +99,30 @@ asynStatus PIInterface::sendAndReceive(const char *outputBuff, char *inputBuff, 
     asynStatus status;
     size_t pos = 0;
     asynPrint(logSink, ASYN_TRACEIO_DRIVER,
-    		"PIInterface::sendAndReceive() sending \"%s\"\n", outputBuff);
+            "PIInterface::sendAndReceive() sending \"%s\"\n", outputBuff);
 //    //printf("PIInterface::sendAndReceive() sending \"%s\"\n", outputBuff);
 
     status = pasynOctetSyncIO->write(m_pAsynInterface, outputBuff,
-    		nWriteRequested, TIMEOUT, &nWrite);
+            nWriteRequested, TIMEOUT, &nWrite);
     if (nWrite != nWriteRequested)
-	{
+    {
         asynPrint(logSink, ASYN_TRACE_ERROR|ASYN_TRACEIO_DRIVER,
                   "PIGCSController:sendAndReceive error calling write, output=%s status=%d, error=%s\n",
                   outputBuff, status, m_pAsynInterface->errorMessage);
-    	return asynError;
-	}
+        return asynError;
+    }
 
      status = pasynOctetSyncIO->writeRead(m_pAsynInterface,
                                          "\n", 1,
                                          inputBuff, inputSize,
                                          TIMEOUT, &nWrite, &nRead, &eomReason);
     if (nWrite != 1)
-	{
+    {
         asynPrint(logSink, ASYN_TRACE_ERROR|ASYN_TRACEIO_DRIVER,
                   "PIGCSController:sendAndReceive error calling write, output=%s status=%d, error=%s\n",
                   outputBuff, status, m_pAsynInterface->errorMessage);
-    	return asynError;
-	}
+        return asynError;
+    }
 
     if (status != asynSuccess)
     {
@@ -132,15 +132,15 @@ asynStatus PIInterface::sendAndReceive(const char *outputBuff, char *inputBuff, 
     }
     while(inputBuff[strlen(inputBuff)-1] == ' ')
     {
-    	inputBuff[strlen(inputBuff)] = '\n';
-    	pos += nRead + 1;
+        inputBuff[strlen(inputBuff)] = '\n';
+        pos += nRead + 1;
         status = pasynOctetSyncIO->read(m_pAsynInterface,
                                              inputBuff+pos, inputSize-pos,
                                              TIMEOUT, &nRead, &eomReason);
 
     }
     asynPrint(logSink, ASYN_TRACEIO_DRIVER,
-    		"PIInterface::sendAndReceive() received \"%s\"\n", inputBuff);
+            "PIInterface::sendAndReceive() received \"%s\"\n", inputBuff);
  //   //printf("PIInterface::sendAndReceive() received \"%s\"\n", inputBuff);
 
    return(status);
@@ -149,46 +149,46 @@ asynStatus PIInterface::sendAndReceive(const char *outputBuff, char *inputBuff, 
 
 asynStatus PIInterface::sendOnly(const char *outputBuff)
 {
-	asynUser* logSink = m_pCurrentLogSink;
-	if (NULL == logSink)
-		logSink = m_pAsynInterface;
-	m_interfaceMutex.lock();
-	asynStatus status =  sendOnly(outputBuff, logSink);
-	m_interfaceMutex.unlock();
-	return status;
+    asynUser* logSink = m_pCurrentLogSink;
+    if (NULL == logSink)
+        logSink = m_pAsynInterface;
+    m_interfaceMutex.lock();
+    asynStatus status =  sendOnly(outputBuff, logSink);
+    m_interfaceMutex.unlock();
+    return status;
 }
 
 asynStatus PIInterface::sendOnly(char c)
 {
-	asynUser* logSink = m_pCurrentLogSink;
-	if (NULL == logSink)
-		logSink = m_pAsynInterface;
-	m_interfaceMutex.lock();
-	asynStatus status =  sendOnly(c, logSink);
-	m_interfaceMutex.unlock();
-	return status;
+    asynUser* logSink = m_pCurrentLogSink;
+    if (NULL == logSink)
+        logSink = m_pAsynInterface;
+    m_interfaceMutex.lock();
+    asynStatus status =  sendOnly(c, logSink);
+    m_interfaceMutex.unlock();
+    return status;
 }
 
 asynStatus PIInterface::sendAndReceive(char c, char *inputBuff, int inputSize)
 {
-	asynUser* logSink = m_pCurrentLogSink;
-	if (NULL == logSink)
-		logSink = m_pAsynInterface;
-	m_interfaceMutex.lock();
-	asynStatus status = sendAndReceive(c, inputBuff, inputSize, logSink);
-	m_interfaceMutex.unlock();
-	return status;
+    asynUser* logSink = m_pCurrentLogSink;
+    if (NULL == logSink)
+        logSink = m_pAsynInterface;
+    m_interfaceMutex.lock();
+    asynStatus status = sendAndReceive(c, inputBuff, inputSize, logSink);
+    m_interfaceMutex.unlock();
+    return status;
 }
 
 asynStatus PIInterface::sendAndReceive(const char* output, char *inputBuff, int inputSize)
 {
-	asynUser* logSink = m_pCurrentLogSink;
-	if (NULL == logSink)
-		logSink = m_pAsynInterface;
-	m_interfaceMutex.lock();
-	asynStatus status = sendAndReceive(output, inputBuff, inputSize, logSink);
-	m_interfaceMutex.unlock();
-	return status;
+    asynUser* logSink = m_pCurrentLogSink;
+    if (NULL == logSink)
+        logSink = m_pAsynInterface;
+    m_interfaceMutex.lock();
+    asynStatus status = sendAndReceive(output, inputBuff, inputSize, logSink);
+    m_interfaceMutex.unlock();
+    return status;
 }
 
 asynStatus PIInterface::sendAndReceive(char c, char *inputBuff, int inputSize, asynUser* logSink)
@@ -199,14 +199,14 @@ asynStatus PIInterface::sendAndReceive(char c, char *inputBuff, int inputSize, a
     size_t pos = 0;
 
     asynPrint(logSink, ASYN_TRACEIO_DRIVER,
-    		"PIInterface::sendAndReceive() sending \"#%d\"\n", int(c));
+            "PIInterface::sendAndReceive() sending \"#%d\"\n", int(c));
     //printf("PIInterface::sendAndReceive() sending \"#%d\"\n", int(c));
     status = pasynOctetSyncIO->writeRead(m_pAsynInterface,
                                          &c, 1,
                                          inputBuff, inputSize,
                                          TIMEOUT, &nWrite, &nRead, &eomReason);
     if (nWrite != 1)
-		status = asynError;
+        status = asynError;
 
     if (status != asynSuccess)
     {
@@ -218,15 +218,15 @@ asynStatus PIInterface::sendAndReceive(char c, char *inputBuff, int inputSize, a
 
     while(inputBuff[strlen(inputBuff)-1] == ' ')
     {
-    	pos += nRead;
+        pos += nRead;
         status = pasynOctetSyncIO->writeRead(m_pAsynInterface,
                                              &c, 1,
                                              inputBuff+pos, inputSize-pos,
                                              TIMEOUT, &nWrite, &nRead, &eomReason);
-//printf("PIInterface::sendAndReceive(char) in while loop. inputBuff: \"%s\"\n", inputBuff);
+    //printf("PIInterface::sendAndReceive(char) in while loop. inputBuff: \"%s\"\n", inputBuff);
     }
     asynPrint(logSink, ASYN_TRACEIO_DRIVER,
-    		"PIInterface::sendAndReceive() received \"%s\"\n", inputBuff);
+            "PIInterface::sendAndReceive() received \"%s\"\n", inputBuff);
     //printf("PIInterface::sendAndReceive() received \"%s\" - (0x%02X)\n", inputBuff, int(inputBuff[0]));
 
     return(status);

--- a/pigcs2App/src/PIasynAxis.cpp
+++ b/pigcs2App/src/PIasynAxis.cpp
@@ -172,6 +172,8 @@ asynStatus PIasynAxis::poll(bool *returnMoving)
 			m_pGCSController->getAxisOvf(this, axisovf);
 			setIntegerParam(pController_->m_CloseLoopValue.PI_SUP_RBOVF,axisovf);
 
+			m_pGCSController->getTravelLimits(this, negLimit_, posLimit_);
+
 			for(unsigned int param=0 ; param<PIGCS2_CL_PARAM_QTT ; param++)
 			{
 				double ValueAxisParam=0;
@@ -197,6 +199,8 @@ asynStatus PIasynAxis::poll(bool *returnMoving)
     setIntegerParam(pController_->motorStatusGainSupport_,	true);
     setIntegerParam(pController_->motorStatusProblem_,		m_bProblem);
     setIntegerParam(pController_->motorStatusPowerOn_,		m_bServoControl);
+    setDoubleParam(pController_->motorLowLimit_, 			negLimit_);
+    setDoubleParam(pController_->motorHighLimit_, 		    posLimit_);
     setIntegerParam(pController_->PI_SUP_SERVO,	      		m_bServoControl );
 
     callParamCallbacks();

--- a/pigcs2App/src/PIasynAxis.h
+++ b/pigcs2App/src/PIasynAxis.h
@@ -18,7 +18,6 @@ Based on drvMotorSim.c, Mark Rivers, December 13, 2009
 
 #include <asynDriver.h> // for asynStatus
 #include <asynMotorAxis.h>
-//#include "PIGCS2PiezoCL.h"
 
 class PIasynController;
 class PIGCSController;

--- a/pigcs2App/src/PIasynController.h
+++ b/pigcs2App/src/PIasynController.h
@@ -18,6 +18,7 @@ December 13, 2009
 #ifndef PI_ASYN_DRIVER_INCLUDED_
 #define PI_ASYN_DRIVER_INCLUDED_
 
+#include <string.h>
 #include "asynMotorController.h"
 #include "asynMotorAxis.h"
 #include "PIGCS2PiezoCL.h"
@@ -30,6 +31,8 @@ public:
     PIasynController(const char *portName, const char* asynPort, int numAxes, int priority, int stackSize, int movingPollPeriod, int idlePollPeriod);
     asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
     asynStatus writeFloat64(asynUser *pasynUser, epicsFloat64 value);
+    asynStatus writeOctet(asynUser *pasynUser, const char *value, size_t maxChars, size_t *nActual);
+
     void report(FILE *fp, int level);
     asynStatus profileMove(asynUser *pasynUser, int npoints, double positions[], double times[], int relative, int trigger);
     asynStatus triggerProfile(asynUser *pasynUser);
@@ -67,6 +70,12 @@ private:
     int PI_SUP_RBPIVOT_Y;
     int PI_SUP_RBPIVOT_Z;
 
+    int PI_CS_TARGETMODE;
+    int PI_CS_ACTIVATE;
+    int PI_CS_LINK;
+    int PI_CS_KST;
+    int PI_CS_KSW;
+
 };
 
 #define PI_SUP_POSITION_String		"PI_SUP_POSITION"
@@ -81,6 +90,11 @@ private:
 #define PI_SUP_RBPIVOT_Y_String		"PI_SUP_RBPIVOT_Y"
 #define PI_SUP_RBPIVOT_Z_String		"PI_SUP_RBPIVOT_Z"
 
+#define PI_CS_TARGETMODE_String		"PI_CS_TARGETMODE"
+#define PI_CS_ACTIVATE_String		"PI_CS_ACTIVATE"
+#define PI_CS_LINK_String		    "PI_CS_LINK"
+#define PI_CS_KST_String		    "PI_CS_KST"
+#define PI_CS_KSW_String		    "PI_CS_KSW"
 
 typedef struct PIasynControllerNode {
     ELLNODE node;


### PR DESCRIPTION
- The work-and-tool concept uses a combination of two active, operating coordinate systems ("work coordinate system" and "tool coordinate system").
- Created the PI_SupportCS.db file.
- PV TARGETMODE: define the target mode for controlling the record motor.
- PV functions: Read all existing CS on the controller, read all active CS, activate specific CS, linked two CS to create chains and create/change the offset of a CS (Work or Tool) type.

This new feature controls and manipulates CS plans previously created by the PI software

This does not affect the operation of existing IOC for other hexapods (in this case, do not load the PI_SupportCS.db file) and should work on other controllers with coordinate system support, but only C-887 was included in the instance creation.