### PR TITLE
Initialize m_targetMode in the constructor instead of the header file

### DIFF
--- a/pigcs2App/src/PIGCSController.cpp
+++ b/pigcs2App/src/PIGCSController.cpp
@@ -652,6 +652,7 @@ PIGCSController::PIGCSController(PIInterface* pInterface, const char* szIDN)
 , m_bAnyAxisMoving(false)
 , m_nrFoundAxes(0)
 , m_LastError(0)
+, m_targetMode(0)
 {
 	strncpy(szIdentification, szIDN, 199);
 }

--- a/pigcs2App/src/PIGCSController.h
+++ b/pigcs2App/src/PIGCSController.h
@@ -117,7 +117,7 @@ public:
     static const size_t MAX_NR_AXES = 64;
 	bool m_bAnyAxisMoving;
     int m_LastError;
-    int m_targetMode = 0;
+    int m_targetMode;
 
     static void getStatusFromBitMask(long mask, int& homing, int& moving, int& negLimit, int& posLimit, int& servoControl);
 


### PR DESCRIPTION
Initialize m_targetMode in the constructor instead of the header file